### PR TITLE
Adiciona e Configura o Pytest Randomly

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -18,7 +18,7 @@ jobs:
         run: pip install uv
 
       - name: Instalando Dependências
-        run: uv add pytest
+        run: uv add pytest pytest-cov pytest-randomly
 
       - name: Executando os Testes
-        run: uv run pytest
+        run: uv run pytest -vv --cov --randomly-seed=last

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,7 @@ format = 'ruff check . --fix && ruff format .'
 interrogate = 'interrogate -vv'
 lint = 'ruff check . && ruff check . --diff'
 pre-commit = 'pre-commit run'
-test = 'pytest -vv'
-test-cov = 'pytest --cov'
+test = 'uv run pytest -vv --cov --randomly-seed=last'
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dev-dependencies = [
     "mkdocstrings>=0.26.1",
     "pre-commit>=3.8.0",
     "pytest-cov>=5.0.0",
+    "pytest-randomly>=3.15.0",
     "pytest>=8.3.3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -533,6 +533,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-randomly"
+version = "3.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/d4/6e924a0b2855736d942703dec88dfc98b4fe0881c8fa849b6b0fbb9182fa/pytest_randomly-3.15.0.tar.gz", hash = "sha256:b908529648667ba5e54723088edd6f82252f540cc340d748d1fa985539687047", size = 21743 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/d3/00e575657422055c4ea220b2f80e8cc6026ab7130372b7067444d1b0ac10/pytest_randomly-3.15.0-py3-none-any.whl", hash = "sha256:0516f4344b29f4e9cdae8bce31c4aeebf59d0b9ef05927c33354ff3859eeeca6", size = 8685 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -712,6 +724,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
 ]
 
 [package.metadata]
@@ -730,6 +743,7 @@ dev = [
     { name = "pre-commit", specifier = ">=3.8.0" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-randomly", specifier = ">=3.15.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🎯 Objetivo

Nessa Pull Request, adicionamos o Pytest Randomly como dependência do Projeto para evitar que testes tenham dependências uns com os outros.

---

## 🛠️ Alterações Propostas

- Adiciona o Pytest Randomly como dependência do projeto;
- Alteramos o Fluxo de Testes;

---

## 🔧 Tipo de Mudança

- [ ] Feature
- [ ] Bug
- [ ] Melhoria
- [ ] Refatoração
- [ ] Documentação
- [X] Teste
- [ ] Outro (Descreva)

---

## 🔗 Relacionado (Se Aplicável)

[Issue 6](https://github.com/dadocracia/template_python_project/issues/6)